### PR TITLE
Fix sort_by in reccard.py to avoid sorting errors (#199)

### DIFF
--- a/src/gourmand/reccard.py
+++ b/src/gourmand/reccard.py
@@ -2814,16 +2814,23 @@ class RecSelector(RecIndex):
 
     @property
     def sort_by(self):
-        preferences = self.prefs["sort_by"]
-        column, ascending = preferences.values()
-        ascending = 1 if ascending else -1
-        return ([column, ascending],)
+        preferences = self.prefs.get("sort_by", {"name": True})
+        ret = []
+        for column, ascending in preferences.items():
+            ascending = 1 if ascending else -1
+            ret.append((column, ascending))
+        return ret
 
     @sort_by.setter
     def sort_by(self, value):
-        column, ascending = value[-1]
-        ascending = True if ascending == 1 else False  # -1
-        self.prefs["sort_by"] = {"column": column, "ascending": ascending}
+        if not value:
+            self.prefs.pop("sort_by", None)
+        else:
+            d = {}
+            for column, ascending in value:
+                ascending = True if ascending == 1 else False
+                d[column] = ascending
+            self.prefs["sort_by"] = d
 
     def setup_main_window(self):
         d = Gtk.Dialog(

--- a/tests/test_reccard_sortby.py
+++ b/tests/test_reccard_sortby.py
@@ -1,0 +1,48 @@
+from unittest import mock
+
+from gourmand.main import get_application
+from gourmand.reccard import RecSelector
+
+
+def test_sort_by(tmp_path):
+    """Test the sort_by property of the RecSelector class."""
+    with mock.patch("gourmand.gglobals.gourmanddir", tmp_path):
+        rec_gui = get_application()
+
+        # Mock UI-related calls within the RecSelector constructor to prevent
+        # windows from being created during the test run.
+        with mock.patch("gourmand.reccard.RecIndex.__init__", return_value=None), \
+                mock.patch("gi.repository.Gtk.Dialog") as mock_dialog, \
+                mock.patch("gi.repository.Gtk.Builder.get_object"):
+            # The RecSelector constructor calls self.dialog.run(). We ensure the mock
+            # for Gtk.Dialog doesn't block the test execution.
+            mock_dialog.return_value.run.return_value = None
+
+            # The RecSelector constructor expects an IngredientEditorModule instance.
+            # We can mock this dependency.
+            mock_ing_editor = mock.Mock()
+
+            # Instantiate the class under test
+            rec_selector = RecSelector(rec_gui, mock_ing_editor)
+
+            # Test setting the sort_by property
+            sort_order = [("name", 1), ("rating", -1)]
+            rec_selector.sort_by = sort_order
+
+            # Test the getter - use set to ignore order
+            assert set(rec_selector.sort_by) == set(sort_order)
+
+            # Test the underlying preference. RecSelector and rec_gui share
+            # the same singleton Prefs instance.
+            expected_prefs = {"name": True, "rating": False}
+            assert rec_gui.prefs.get("sort_by") == expected_prefs
+
+            # Test setting an empty value
+            rec_selector.sort_by = []
+            assert "sort_by" not in rec_gui.prefs
+
+            # Test setting to None
+            rec_selector.sort_by = sort_order  # set it again
+            assert "sort_by" in rec_gui.prefs
+            rec_selector.sort_by = None
+            assert "sort_by" not in rec_gui.prefs


### PR DESCRIPTION
Before, sort_by was returning a weird tuple-within-list and saving prefs in a format that didn’t match what the rest of the code expects. That was causing errors like 'str' object has no attribute 'type' when sorting. Now the getter/setter use the same format as main.py: a dict internally and a list of (column, direction) tuples on return. This should fix the issue.

Closes #150.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
